### PR TITLE
 Enable GitHub Actions builds for pull requests. Add PR preview deployments to workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -65,9 +65,9 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
   
-  # Preview deployment (runs on pull requests)
+  # Preview deployment (runs on pull requests in forks only, not upstream)
   deploy-preview:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.repository_owner != 'stratomercata'
     environment:
       name: pr-preview-${{ github.event.pull_request.number }}
       url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
 Enable GitHub Actions builds for pull requests

- Added pull_request trigger to workflow to build PRs targeting main
- Added conditional to deploy job to only deploy on pushes to main (not PRs)
- This allows PR validation without deploying unmerged changes

Add PR preview deployments to workflow
- Split deployment into production and preview jobs
- Production: deploys to main github-pages (push to main only)
- Preview: deploys PRs to gh-pages-preview branch with PR-specific subdirectories
- Automatically comments on PRs with preview URL
- Updates existing comment on subsequent pushes to PR

Preview URLs format: [https://owner.github.io/repo/pr-{number}](https://owner.github.io/repo/pr-%7Bnumber%7D)