### PR TITLE
Make embedded videos and articles full-width on mobile devices

### DIFF
--- a/source/assets/css/common.css
+++ b/source/assets/css/common.css
@@ -1562,3 +1562,13 @@ article .blog-tags .tag {
     padding: 3rem 0;
   }
 }
+
+/* Mobile: Make embeds full width */
+@media (max-width: 767px) {
+  .blog-embed-card,
+  .content-embed-card {
+    width: calc(100% - 18px);
+    display: block;
+    margin: 18px 9px;
+  }
+}


### PR DESCRIPTION
Make embedded videos and articles full-width on mobile devices

This commit improves the mobile user experience on video pages by making all embedded content (videos and article cards) display at full width on screens below 768px, while maintaining the existing 50% width layout on desktop devices.

Changes:
- Added mobile-specific CSS media query (@media max-width: 767px)
- Updated .blog-embed-card and .content-embed-card to use full width (calc(100% - 18px)) on mobile
- Changed display from inline-block to block on mobile
- Desktop layout (768px+) remains unchanged

Affected pages:
- All video detail pages (e.g., /videos/institutions-want-tokens-how-is-ethereum-keeping-up/)
- Any pages using content-embed.html include

Technical details:
- Maintains 9px horizontal margins on mobile for spacing
- Preserves hover effects and transitions
- No changes to desktop breakpoint behavior