### PR TITLE
Add markdown link support to auto_link.html for external hyperlinks in descriptions

### DIFF
--- a/source/_includes/auto_link.html
+++ b/source/_includes/auto_link.html
@@ -23,6 +23,31 @@ while ensuring clean, valid HTML output.
 
 {%- assign body_content = include.content -%}
 
+{%- comment -%}Convert markdown-style links [text](url) to HTML{%- endcomment -%}
+{%- assign md_parts = body_content | split: '[' -%}
+{%- assign converted = "" -%}
+{%- for part in md_parts -%}
+  {%- if forloop.first -%}
+    {%- assign converted = part -%}
+  {%- else -%}
+    {%- assign close_bracket = part | split: '](' -%}
+    {%- if close_bracket.size > 1 -%}
+      {%- assign link_text = close_bracket[0] -%}
+      {%- assign url_part = close_bracket[1] | split: ')' -%}
+      {%- if url_part.size > 1 -%}
+        {%- assign url = url_part[0] -%}
+        {%- assign rest = url_part[1] -%}
+        {%- assign converted = converted | append: '<a href="' | append: url | append: '">' | append: link_text | append: '</a>' | append: rest -%}
+      {%- else -%}
+        {%- assign converted = converted | append: '[' | append: part -%}
+      {%- endif -%}
+    {%- else -%}
+      {%- assign converted = converted | append: '[' | append: part -%}
+    {%- endif -%}
+  {%- endif -%}
+{%- endfor -%}
+{%- assign body_content = converted -%}
+
 {%- comment -%}Remove links to non-existent people profiles{%- endcomment -%}
 {%- comment -%}Find all links to /people/ and check if the person exists{%- endcomment -%}
 {%- assign people_link_parts = body_content | split: '<a href="' -%}

--- a/source/_videos/institutions-want-tokens-how-is-ethereum-keeping-up.md
+++ b/source/_videos/institutions-want-tokens-how-is-ethereum-keeping-up.md
@@ -3,7 +3,7 @@ title: "Institutions Want Tokens - How is Ethereum Keeping Up?"
 date: 2025-10-15
 hosts: ["Bob Summerwill", "Victor Wong", "Kieren James-Lubin"]
 guests: ["Redwan Meslem"]
-description: "We were joined by Redwan Meslem, the Executive Director of the Enterprise Ethereum Alliance, and talked about the history of the [EEA](https://entethalliance.org) and about the present institutional landscape"
+description: "We were joined by [Redwan Meslem](https://x.com/RedoudouM), the Executive Director of the [Enterprise Ethereum Alliance](https://entethalliance.org), and talked about the history of the [EEA](https://entethalliance.org) and about the present institutional landscape"
 img: https://img.youtube.com/vi/CNavXFv3ats/maxresdefault.jpg
 embed:
   url: https://www.youtube.com/embed/CNavXFv3ats


### PR DESCRIPTION
- Enhanced auto_link.html to convert markdown-style links [text](url) to HTML
- Uses manual string parsing to avoid markdownify's <p> tag wrapping issues
- Fixes issue where markdown links in video descriptions weren't being rendered
- Example: [EEA](https://entethalliance.org) now renders as clickable link
- Implementation uses Liquid split/join operations for safe conversion
- Maintains compatibility with existing auto-linking functionality
- Updated institutions-want-tokens video description to use markdown links

This allows content authors to include external hyperlinks in video/blog descriptions using familiar markdown syntax without breaking the build.